### PR TITLE
Fixed sparse accessor validation

### DIFF
--- a/lib/src/base/accessor.dart
+++ b/lib/src/base/accessor.dart
@@ -482,7 +482,7 @@ class Accessor extends GltfChildOfRootProperty {
           }
 
           if (index == sparseIndex) {
-            yield values[sparsePosition * components + componentIndex];
+            yield element + values[sparsePosition * components + componentIndex];
           } else {
             yield element;
           }

--- a/test/base/10.3_accessor_get_elements_sparse_test.dart
+++ b/test/base/10.3_accessor_get_elements_sparse_test.dart
@@ -53,7 +53,7 @@ void main() {
     test('Partially overridden', () async {
       final elements = result.gltf.accessors[2].getElements().toList();
 
-      expect(elements, orderedEquals(<int>[70000, 100001, 54321, 200002]));
+      expect(elements, orderedEquals(<int>[70000, 100001, 54321, 206791]));
     });
   });
 }


### PR DESCRIPTION
For the sparse accessor sample that I created for https://github.com/KhronosGroup/glTF-Sample-Models/issues/99#issuecomment-327335065 , the validator reported an error:

           "ACCESSOR_MAX_MISMATCH": [
                {
                    "type": "ACCESSOR_MAX_MISMATCH",
                    "path": "#/accessors/1/max",
                    "message": "Declared maximum value for component `1` (`4`) does not match actual one (`3`)."
                }
            ]

According to my understanding, the values that are stored in the sparse accessors are really *displacements*. They are not supposed to *replace* the original values. Instead, they should be *added* to the original values.

(Maybe the spec could be reworded slightly. It refers to this process as "substitution", which sounds like the values should be *replaced*. Referring to it as "displacement" or "deformation" might be less confusing. I also stumbled over this, and fixed it in https://github.com/javagl/JglTF/commit/6eac4bc29ccd77d22a9ffe78d597ca522f2f8231 )



