### PR TITLE
Fix ISSUES.md on Windows Git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+ISSUES.md text eol=lf


### PR DESCRIPTION
This tells Git that `ISSUES.md` will always be generated with Linux-style line endings, regardless of local platform.