### PR TITLE
Move the node_modules folder out of build/npm

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 ISSUES.md text eol=lf
+tool/npm_template/package.json eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ doc/api/
 # Don't commit pubspec lock file 
 # (Library packages only! Remove pattern if developing an application package)
 pubspec.lock
+
+# Node Modules
+tool/npm_template/node_modules/

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -177,19 +177,20 @@ void npmRelease() {
       .writeAsStringSync((const JsonEncoder.withIndent('    ')).convert(json));
 
   copy(new File(p.join(sourceDir, 'index.js')), dir);
-  copy(new File(p.join(sourceDir, 'README.md')), dir);
   copy(new File('ISSUES.md'), dir);
   copy(new File('LICENSE'), dir);
   copy(new File('3RD_PARTY'), dir);
   copy(new File(p.join('docs', 'validation.schema.json')), dir);
+
+  log("Building npm README...");
+  run(npmExecutable, arguments: ['install'], workingDirectory: 'tool/npm_template');
+  copy(new File(p.join(sourceDir, 'README.md')), dir);
+  run(npmExecutable, arguments: ['run', 'docs'], workingDirectory: 'tool/npm_template');
 }
 
 @Depends(issues, npmRelease)
 @Task('Build an npm package.')
 void npm() {
-  log("Trying to generate npm docs...");
-  run(npmExecutable, arguments: ['install'], workingDirectory: 'build/npm');
-  run(npmExecutable, arguments: ['run', 'docs'], workingDirectory: 'build/npm');
 }
 
 @Depends(npm)

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -177,20 +177,19 @@ void npmRelease() {
       .writeAsStringSync((const JsonEncoder.withIndent('    ')).convert(json));
 
   copy(new File(p.join(sourceDir, 'index.js')), dir);
+  copy(new File(p.join(sourceDir, 'README.md')), dir);
   copy(new File('ISSUES.md'), dir);
   copy(new File('LICENSE'), dir);
   copy(new File('3RD_PARTY'), dir);
   copy(new File(p.join('docs', 'validation.schema.json')), dir);
-
-  log("Building npm README...");
-  run(npmExecutable, arguments: ['install'], workingDirectory: 'tool/npm_template');
-  copy(new File(p.join(sourceDir, 'README.md')), dir);
-  run(npmExecutable, arguments: ['run', 'docs'], workingDirectory: 'tool/npm_template');
 }
 
 @Depends(issues, npmRelease)
 @Task('Build an npm package.')
 void npm() {
+  log("Building npm README...");
+  run(npmExecutable, arguments: ['install'], workingDirectory: 'tool/npm_template');
+  run(npmExecutable, arguments: ['run', 'docs'], workingDirectory: 'tool/npm_template');
 }
 
 @Depends(npm)

--- a/tool/npm_template/.npmrc
+++ b/tool/npm_template/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/tool/npm_template/package.json
+++ b/tool/npm_template/package.json
@@ -22,6 +22,6 @@
         "replace-between": "0.0.8"
     },
     "scripts": {
-        "docs": "documentation build index.js --shallow -f md | replace-between --target README.md --token API"
+        "docs": "documentation build index.js --shallow -f md | replace-between --target ../../build/npm/README.md --token API"
     }
 }


### PR DESCRIPTION
The node_modules folder contains almost 10000 files that are destroyed and recreated with every build of the npm package.  This kind of thrashing is not the intended use pattern for npm, and it takes some time to delete and re-copy that many files (at least on my machine).

This change moves `node_modules` to under the `tool/npm_template` folder, where it can survive between clean builds, as intended.

There are some additional supporting changes here:

* `.gitattributes` because npm 8 for all platforms writes Unix-style line endings to package.json
* `.gitignore` now ignores the new location for `node_modules`.
* `grind.dart` now runs the doc builder directly in `tool/npm_template` working folder, although it does not modify any contents there.
* `package.json` modified to cause the built docs to always save to the build folder, even when run from the template folder.

As a sanity check, I did a folder-diff of the results on this branch with what was published with the most recent release.  The results are identical, except for the intentional edit to the `package.json` doc script.  So, no need to bump the version number or re-publish this to npm, as there are no meaningful changes to the build output folder itself.