### PR TITLE
Tighten up skinning requirement on primitives

### DIFF
--- a/lib/src/base/node.dart
+++ b/lib/src/base/node.dart
@@ -196,7 +196,7 @@ class Node extends GltfChildOfRootProperty {
           }
 
           if (_skin != null &&
-              !mesh.primitives.any((primitive) => primitive.jointsCount > 0)) {
+              mesh.primitives.any((primitive) => primitive.jointsCount == 0)) {
             context.addIssue(LinkError.nodeSkinWithNonSkinnedMesh);
           }
         }

--- a/lib/src/base/node.dart
+++ b/lib/src/base/node.dart
@@ -186,18 +186,24 @@ class Node extends GltfChildOfRootProperty {
         if (_mesh == null) {
           context.addIssue(LinkError.unresolvedReference,
               name: MESH, args: [_meshIndex]);
-        } else {
+        } else if (mesh.primitives != null) {
           if (weights != null &&
-              _mesh.primitives != null &&
               _mesh.primitives[0].targets?.length != weights.length) {
             context.addIssue(LinkError.nodeWeightsInvalid,
                 name: WEIGHTS,
                 args: [weights.length, mesh.primitives[0].targets?.length]);
           }
 
-          if (_skin != null &&
-              mesh.primitives.any((primitive) => primitive.jointsCount == 0)) {
-            context.addIssue(LinkError.nodeSkinWithNonSkinnedMesh);
+          if (_skin != null) {
+            if (mesh.primitives
+                .any((primitive) => primitive.jointsCount == 0)) {
+              context.addIssue(LinkError.nodeSkinWithNonSkinnedMesh);
+            }
+          } else {
+            if (mesh.primitives
+                .any((primitive) => primitive.jointsCount != 0)) {
+              context.addIssue(LinkError.nodeSkinnedMeshWithoutSkin);
+            }
           }
         }
       }

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -528,8 +528,13 @@ class LinkError extends IssueType {
           'the number of morph targets (${args[1] ?? 0}).');
 
   static final LinkError nodeSkinWithNonSkinnedMesh = new LinkError._(
-      'NODE_WITH_NON_SKINNED_MESH',
+      'NODE_SKIN_WITH_NON_SKINNED_MESH',
       (args) => 'Node has skin defined, but mesh has no joints data.');
+
+  static final LinkError nodeSkinnedMeshWithoutSkin = new LinkError._(
+      'NODE_SKINNED_MESH_WITHOUT_SKIN',
+      (args) => 'Node uses skinned mesh, but has no skin defined.',
+      Severity.Warning);
 
   static final LinkError sceneNonRootNode = new LinkError._(
       'SCENE_NON_ROOT_NODE', (args) => 'Node ${args[0]} is not a root node.');

--- a/test/base/12_node_test.dart
+++ b/test/base/12_node_test.dart
@@ -104,7 +104,8 @@ void main() {
         ..path.removeLast()
         ..path.removeLast()
         ..addIssue(LinkError.nodeLoop, index: 2)
-        ..addIssue(LinkError.nodeLoop, index: 3);
+        ..addIssue(LinkError.nodeLoop, index: 3)
+        ..addIssue(LinkError.nodeSkinnedMeshWithoutSkin, index: 4);
 
       await reader.read();
 

--- a/test/base/data/node/misc.gltf
+++ b/test/base/data/node/misc.gltf
@@ -21,6 +21,9 @@
         },
         {
             "children": [2]
+        },
+        {
+            "mesh": 1
         }
     ],
     "meshes": [
@@ -29,6 +32,17 @@
                 {
                     "attributes": {
                         "POSITION": 0
+                    }
+                }
+            ]
+        },
+        {
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0,
+                        "JOINTS_0": 1,
+                        "WEIGHTS_0": 2
                     }
                 }
             ]
@@ -41,6 +55,16 @@
             "count": 3,
             "min": [0, 0, 0],
             "max": [1, 1, 1]
+        },
+        {
+            "type": "VEC4",
+            "componentType": 5123,
+            "count": 3
+        },
+        {
+            "type": "VEC4",
+            "componentType": 5126,
+            "count": 3
         }
     ],
     "skins": [


### PR DESCRIPTION
Spec says: ***When the node contains `skin`, all `mesh.primitives` must contain `JOINTS_0` and `WEIGHTS_0` attributes.***

That makes sense to me, but maybe it's this code that's right, in which case we should update the spec.