### PR TITLE
Add note about embedded buffers and externalResourceFunction

### DIFF
--- a/tool/npm_template/index.js
+++ b/tool/npm_template/index.js
@@ -35,7 +35,7 @@ exports.validateString = (json, options) => validator.validateString(json, optio
 /**
  @typedef {Object} ValidationOptions
  @property {string} uri - Absolute or relative asset URI that will be copied to validation report.
- @property {ExternalResourceFunction} externalResourceFunction - Function for loading external resources. If omitted, external resources are not validated.
+ @property {ExternalResourceFunction} externalResourceFunction - Function for loading external resources. If omitted, neither external resources nor embedded buffers are validated.
  @property {boolean} validateAccessorData - Set to `false` to skip reading of accessor data.
  @property {number} maxIssues - Max number of reported issues. Use `0` for unlimited output.
  @property {string[]} ignoredIssues - Array of ignored issue codes.


### PR DESCRIPTION
I noticed while adding resource validation to https://gltf-viewer.donmccurdy.com/ (it's working great, thanks!) that omitting `externalResourceFunction` not only disables validation of external resources, but also of embedded buffers.

Probably this should either be fixed or noted in the docs; this PR does the latter.