### PR TITLE
2.0.0-dev.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-dev.2.0
 
-* Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` severities to Warning (#77).
+* Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` default severities to Warning (#77).
 
 * Using custom image format no longer issues `UNSATISFIED_DEPENDENCY` (#77).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Buffers with broken URIs are no longer treated as GLB-stored.
 
+* Fixed a crash on images with broken URIs.
+
 * Updated validation report schema.
 
 ## 2.0.0-dev.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-dev.1.9
+
+* Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` severities to Warning (#77).
+
+* Using custom image format no longer issues `UNSATISFIED_DEPENDENCY` (#77).
+
 ## 2.0.0-dev.1.8
 
 * Added `MESH_PRIMITIVE_UNUSED_TEXCOORD` issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 2.0.0-dev.1.9
+## 2.0.0-dev.2.0
 
 * Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` severities to Warning (#77).
 
 * Using custom image format no longer issues `UNSATISFIED_DEPENDENCY` (#77).
+
+* Improved pointers for not found resources.
+
+* Buffers with broken URIs are no longer treated as GLB-stored.
+
+* Updated validation report schema.
 
 ## 2.0.0-dev.1.8
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -20,7 +20,7 @@
 |UNEXPECTED_PROPERTY|Unexpected property.|Warning|
 |UNSATISFIED_DEPENDENCY|Dependency failed. '`%1`' must be defined.|Error|
 |VALUE_MULTIPLE_OF|Value `%1` is not a multiple of `%2`.|Error|
-|VALUE_NOT_IN_LIST|Invalid value '`%1`'. Valid values are ('`%a`', '`%b`', '`%c`').|Error|
+|VALUE_NOT_IN_LIST|Invalid value '`%1`'. Valid values are ('`%a`', '`%b`', '`%c`').|Warning|
 |VALUE_NOT_IN_RANGE|Value `%1` is out of range.|Error|
 ## SemanticError
 | Code | Message | Severity |
@@ -126,7 +126,7 @@
 |IMAGE_MIME_TYPE_INVALID|Recognized image format '`%1`' does not match declared image format '`%2`'.|Error|
 |IMAGE_NPOT_DIMENSIONS|Image has non-power-of-two dimensions: `%1`x`%2`.|Information|
 |IMAGE_UNEXPECTED_EOS|Unexpected end of image stream.|Error|
-|IMAGE_UNRECOGNIZED_FORMAT|Image format not recognized.|Error|
+|IMAGE_UNRECOGNIZED_FORMAT|Image format not recognized.|Warning|
 ## GlbError
 | Code | Message | Severity |
 |------|---------|----------|

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -12,7 +12,7 @@
 |EMPTY_ENTITY|Entity cannot be empty.|Error|
 |INVALID_INDEX|Index must be a non-negative integer.|Error|
 |INVALID_JSON|Invalid JSON data. Parser output: `%1`|Error|
-|INVALID_URI|Invalid URI `%1`. Parser output: `%2`|Error|
+|INVALID_URI|Invalid URI '`%1`'. Parser output: `%2`|Error|
 |ONE_OF_MISMATCH|Exactly one of ('`%1`', '`%2`', '`%3`', '`%4`') properties must be defined.|Error|
 |PATTERN_MISMATCH|Value '`%1`' does not match regexp pattern '`%2`'.|Error|
 |TYPE_MISMATCH|Type mismatch. Property value '`%1`' is not a '`%2`'.|Error|

--- a/docs/validation.schema.json
+++ b/docs/validation.schema.json
@@ -187,8 +187,8 @@
                             "storage": {
                                 "oneOf": [
                                     {
-                                        "const": "base64",
-                                        "description": "Resource is stored as Base 64 URI."
+                                        "const": "data-uri",
+                                        "description": "Resource is stored as Data-URI."
                                     },
                                     {
                                         "const": "bufferView",
@@ -201,6 +201,10 @@
                                     {
                                         "const": "external",
                                         "description": "Resource is stored externally."
+                                    },
+                                    {
+                                        "const": null,
+                                        "description": "Resource storage type is unknown."
                                     }
                                 ]
                             },

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -193,6 +193,13 @@ class Context {
   }
 
   void addResource(Map<String, Object> info) => _resources.add(info);
+
+  bool _isGlb = false;
+  bool get isGlb => _isGlb;
+
+  void setGlb() {
+    _isGlb = true;
+  }
 }
 
 class IssuesLimitExceededException implements Exception {

--- a/lib/src/data_access/resources_loader.dart
+++ b/lib/src/data_access/resources_loader.dart
@@ -124,9 +124,8 @@ class ResourcesLoader {
             }
             return data;
           }
-        } else {
-          throw new UnimplementedError();
         }
+        return null;
       }
 
       Uint8List data;
@@ -135,7 +134,7 @@ class ResourcesLoader {
         data = await _fetchBuffer(buffer) as Uint8List;
       } on Exception catch (e) {
         // likely IO error
-        context.addIssue(IoError.fileNotFound, args: [e]);
+        context.addIssue(IoError.fileNotFound, args: [e], name: URI);
       }
 
       if (data != null) {
@@ -190,10 +189,8 @@ class ResourcesLoader {
               return new Stream.fromIterable([image.data]);
             }
           }
-          return null;
-        } else {
-          throw new UnimplementedError();
         }
+        return null;
       }
 
       final imageDataStream = _fetchImageData(image);
@@ -210,7 +207,7 @@ class ResourcesLoader {
           context.addIssue(DataError.imageDataInvalid, args: [e]);
         } on Exception catch (e) {
           // likely IO error
-          context.addIssue(IoError.fileNotFound, args: [e]);
+          context.addIssue(IoError.fileNotFound, args: [e], name: URI);
         }
         if (imageInfo != null) {
           resourceInfo.mimeType = imageInfo.mimeType;

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -132,7 +132,9 @@ class DataError extends IssueType {
       'IMAGE_UNEXPECTED_EOS', (args) => 'Unexpected end of image stream.');
 
   static final DataError imageUnrecognizedFormat = new DataError._(
-      'IMAGE_UNRECOGNIZED_FORMAT', (args) => 'Image format not recognized.');
+      'IMAGE_UNRECOGNIZED_FORMAT',
+      (args) => 'Image format not recognized.',
+      Severity.Warning);
 
   static final DataError imageNonPowerOfTwoDimensions = new DataError._(
       'IMAGE_NPOT_DIMENSIONS',
@@ -197,7 +199,8 @@ class SchemaError extends IssueType {
       'VALUE_NOT_IN_LIST',
       (args) => 'Invalid value ${_mbq(args[0])}. '
           // ignore: avoid_as
-          'Valid values are ${(args[1] as Iterable).map(_mbq)}.');
+          'Valid values are ${(args[1] as Iterable).map(_mbq)}.',
+      Severity.Warning);
 
   static final SchemaError valueNotInRange = new SchemaError._(
       'VALUE_NOT_IN_RANGE', (args) => 'Value ${args[0]} is out of range.');

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -177,7 +177,7 @@ class SchemaError extends IssueType {
       'INVALID_JSON', (args) => 'Invalid JSON data. Parser output: ${args[0]}');
 
   static final SchemaError invalidUri = new SchemaError._('INVALID_URI',
-      (args) => 'Invalid URI ${args[0]}. Parser output: ${args[1]}');
+      (args) => 'Invalid URI ${_q(args[0])}. Parser output: ${args[1]}');
 
   static final SchemaError emptyEntity =
       new SchemaError._('EMPTY_ENTITY', (args) => 'Entity cannot be empty.');

--- a/lib/src/glb_reader.dart
+++ b/lib/src/glb_reader.dart
@@ -76,7 +76,7 @@ class GlbReader implements GltfReader {
   Uint8List _binaryBuffer;
 
   GlbReader(this.stream, [Context context]) {
-    _context = context ?? new Context();
+    _context = (context ?? new Context())..setGlb();
     _headerByteData = new ByteData.view(_header.buffer);
     _jsonStreamController = new StreamController<List<int>>();
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -105,15 +105,10 @@ double getFloat(Map<String, Object> map, String name, Context context,
     double min,
     double exclMin,
     double max,
-    double def = double.nan,
-    Iterable<double> list}) {
+    double def = double.nan}) {
   final value = _getGuarded(map, name, _kNumber, context);
   if (value is num) {
-    if (list != null) {
-      if (!checkEnum<num>(name, value, list, context)) {
-        return double.nan;
-      }
-    } else if ((min != null && value < min) ||
+    if ((min != null && value < min) ||
         (exclMin != null && value <= exclMin) ||
         (max != null && value > max)) {
       context.addIssue(SchemaError.valueNotInRange, name: name, args: [value]);
@@ -137,9 +132,7 @@ String getString(Map<String, Object> map, String name, Context context,
   final value = _getGuarded(map, name, _kString, context);
   if (value is String) {
     if (list != null) {
-      if (!checkEnum<String>(name, value, list, context)) {
-        return null;
-      }
+      checkEnum<String>(name, value, list, context);
     } else if (regexp?.hasMatch(value) == false) {
       context.addIssue(SchemaError.patternMismatch,
           name: name, args: [value, regexp.pattern]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.1.9
+version: 2.0.0-dev.2.0
 description: Library for loading and validating glTF 2.0 assets
 author: The Khronos Group Inc.
 homepage: https://github.com/KhronosGroup/glTF-Validator
@@ -23,7 +23,7 @@ dependency_overrides:
   isolate: '2.0.0'
 
 environment:
-  sdk: '>=2.0.0-dev.43.0 <2.0.0'
+  sdk: '>=2.0.0-dev.44.0 <2.0.0'
 
 executables:
   gltf_validator:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.1.8
+version: 2.0.0-dev.1.9
 description: Library for loading and validating glTF 2.0 assets
 author: The Khronos Group Inc.
 homepage: https://github.com/KhronosGroup/glTF-Validator

--- a/test/data_access/00_load_buffers_test.dart
+++ b/test/data_access/00_load_buffers_test.dart
@@ -116,5 +116,19 @@ void main() {
 
       expect(validationResult.context.issues, unorderedMatches(context.issues));
     });
+
+    test('Broken URI', () async {
+      final validationResult =
+          await getValidationResult('test/data_access/buffer/broken_uri.gltf');
+
+      final context = new Context()
+        ..path.add('buffers')
+        ..path.add('0')
+        ..addIssue(SchemaError.invalidUri,
+            name: 'uri',
+            args: ['data:', "FormatException: Expecting '='\ndata:"]);
+
+      expect(validationResult.context.issues, unorderedMatches(context.issues));
+    });
   });
 }

--- a/test/data_access/buffer/broken_uri.gltf
+++ b/test/data_access/buffer/broken_uri.gltf
@@ -1,0 +1,11 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "buffers": [
+        {
+            "uri": "data:",
+            "byteLength": 1
+        }
+    ]
+}


### PR DESCRIPTION
* Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` severities to Warning (#77).
* Using custom image format no longer issues `UNSATISFIED_DEPENDENCY` (#77).
* Improved pointers for not found resources.
* Buffers with broken URIs are no longer treated as GLB-stored.
* Fixed a crash on images with broken URIs.
* Updated validation report schema.