### PR TITLE
2.0.0-dev.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.2.1
+
+* Fixed a crash in the NPM build when `externalResourceFunction` isn't provided (#81).
+
 ## 2.0.0-dev.2.0
 
 * Changed `VALUE_NOT_IN_LIST` and `IMAGE_UNRECOGNIZED_FORMAT` default severities to Warning (#77).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.2.0
+version: 2.0.0-dev.2.1
 description: Library for loading and validating glTF 2.0 assets
 author: The Khronos Group Inc.
 homepage: https://github.com/KhronosGroup/glTF-Validator
@@ -23,7 +23,7 @@ dependency_overrides:
   isolate: '2.0.0'
 
 environment:
-  sdk: '>=2.0.0-dev.44.0 <2.0.0'
+  sdk: '>=2.0.0-dev.45.0 <2.0.0'
 
 executables:
   gltf_validator:

--- a/tool/npm_template/node_wrapper.dart
+++ b/tool/npm_template/node_wrapper.dart
@@ -258,7 +258,7 @@ ResourcesLoader _getResourcesLoader(Context context,
         }
         return getBytes(uri);
       },
-      externalStreamFetch: (uri) => new Stream.fromFuture(getBytes(uri)));
+      externalStreamFetch: (uri) => getBytes(uri)?.asStream());
 }
 
 class NodeException implements Exception {


### PR DESCRIPTION
* Fixed a crash in the NPM build when `externalResourceFunction` isn't provided (#81).

This doesn't affect VS Code or three-gltf-viewer.