### PR TITLE
Only treat first buffer as .glb-embedded

### DIFF
--- a/lib/src/data_access/resources_loader.dart
+++ b/lib/src/data_access/resources_loader.dart
@@ -104,20 +104,21 @@ class ResourcesLoader {
             // Data URI
             info.storage = _Storage.DataUri;
             return buffer.data;
-          } else if (context.isGlb && !buffer.hasUri) {
-            // GLB Buffer
-            info.storage = _Storage.GLB;
-            final data = externalBytesFetch();
-            if (context.validate) {
-              if (i != 0) {
+          } else if (context.isGlb && i == 0) {
+            if (buffer.hasUri) {
+              if (context.validate) {
                 context.addIssue(LinkError.bufferNonFirstGlb);
               }
-
+              return null;
+            } else {
+              // GLB Buffer
+              info.storage = _Storage.GLB;
+              final data = externalBytesFetch();
               if (data == null) {
                 context.addIssue(LinkError.bufferMissingGlbData);
               }
+              return data;
             }
-            return data;
           }
         }
         return null;

--- a/lib/src/data_access/resources_loader.dart
+++ b/lib/src/data_access/resources_loader.dart
@@ -104,16 +104,11 @@ class ResourcesLoader {
             // Data URI
             info.storage = _Storage.DataUri;
             return buffer.data;
-          } else if (context.isGlb && i == 0) {
-            if (buffer.hasUri) {
-              if (context.validate) {
-                context.addIssue(LinkError.bufferNonFirstGlb);
-              }
-              return null;
-            } else {
-              // GLB Buffer
-              info.storage = _Storage.GLB;
-              final data = externalBytesFetch();
+          } else if (context.isGlb && !buffer.hasUri && i == 0) {
+            // GLB Buffer
+            info.storage = _Storage.GLB;
+            final data = externalBytesFetch();
+            if (context.validate) {
               if (data == null) {
                 context.addIssue(LinkError.bufferMissingGlbData);
               }

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -489,9 +489,6 @@ class LinkError extends IssueType {
           (args) => 'Animation sampler output accessor of count '
               '${args[0]} expected. Found ${args[1]}.');
 
-  static final LinkError bufferNonFirstGlb = LinkError._('BUFFER_NON_FIRST_GLB',
-      (args) => 'Buffer referring to GLB binary chunk must be the first.');
-
   static final LinkError bufferMissingGlbData = LinkError._(
       'BUFFER_MISSING_GLB_DATA',
       (args) => 'Buffer refers to an unresolved GLB binary chunk.');

--- a/test/data_access/00_load_buffers_test.dart
+++ b/test/data_access/00_load_buffers_test.dart
@@ -99,15 +99,11 @@ void main() {
       final validationResult = await getValidationResult(
           'test/data_access/buffer/non_first_buffer.glb');
 
-      final context = Context()
-        ..path.add('buffers')
-        ..path.add('0')
-        ..addIssue(DataError.dataUriGlb, name: 'uri')
-        ..path.removeLast()
-        ..path.add('1')
-        ..addIssue(LinkError.bufferNonFirstGlb);
-
-      expect(validationResult.context.issues, unorderedMatches(context.issues));
+      // Note: this GLB file has an orphaned BIN chunk: the buffer without a uri is
+      // not the first and thus it doesn't refer to BIN chunk. This file is unusual
+      // but valid; access to dummy buffers is left undefined to accomodate future
+      // specification versions and extensions.
+      expect(validationResult.context.issues, isEmpty);
     });
 
     test('Missing BIN chunk', () async {

--- a/test/data_access/00_load_buffers_test.dart
+++ b/test/data_access/00_load_buffers_test.dart
@@ -99,11 +99,16 @@ void main() {
       final validationResult = await getValidationResult(
           'test/data_access/buffer/non_first_buffer.glb');
 
+      final context = Context()
+        ..path.add('buffers')
+        ..path.add('0')
+        ..addIssue(DataError.dataUriGlb, name: 'uri');
+
       // Note: this GLB file has an orphaned BIN chunk: the buffer without a uri is
       // not the first and thus it doesn't refer to BIN chunk. This file is unusual
       // but valid; access to dummy buffers is left undefined to accomodate future
       // specification versions and extensions.
-      expect(validationResult.context.issues, isEmpty);
+      expect(validationResult.context.issues, unorderedMatches(context.issues));
     });
 
     test('Missing BIN chunk', () async {

--- a/test/data_access/00_load_buffers_test.dart
+++ b/test/data_access/00_load_buffers_test.dart
@@ -104,10 +104,10 @@ void main() {
         ..path.add('0')
         ..addIssue(DataError.dataUriGlb, name: 'uri');
 
-      // Note: this GLB file has an orphaned BIN chunk: the buffer without a uri is
-      // not the first and thus it doesn't refer to BIN chunk. This file is unusual
-      // but valid; access to dummy buffers is left undefined to accomodate future
-      // specification versions and extensions.
+      // Note: this GLB file has an orphaned BIN chunk: the buffer without uri
+      // is not the first and thus it doesn't refer to BIN chunk. This file is
+      // unusual but valid; access to dummy buffers is left undefined to
+      // accomodate future specification versions and extensions.
       expect(validationResult.context.issues, unorderedMatches(context.issues));
     });
 


### PR DESCRIPTION
Instead of treating all buffers with non-existent URI as being embedded
into GLB file, we only treat the first buffer as embedded - we now emit
a validation error if the first buffer in GLB file has a URI though.

Fixes #121.