### PR TITLE
Native build deleteSync

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -102,7 +102,7 @@ void exe() {
       'gltf_validator${Platform.isWindows ? '.exe' : ''}');
 
   final targetDir = Directory(_getTarget(_binSource));
-  delete(targetDir);
+  targetDir.deleteSync(recursive: true);
   targetDir.createSync(recursive: true);
 
   run(dart2native, arguments: ['bin/gltf_validator.dart', '-v', '-o', output]);


### PR DESCRIPTION
For me, on Win64, the native build often fails unless the delete is run synchronously.

I'm not sure why the npm build doesn't seem to require this, maybe a race condition.