### PR TITLE
Version 2.0.0-dev.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.0.0-dev.3.1
+
+### New Features
+
+* (CLI) When validating a directory, the validator now additionally lists assets with errors in the end.
+
+### Bugfixes
+
+* (CLI) Await until the report is written and flushed to disk (#126).
+
+* (npm) Fixed crash on missing validation options JS object (introduced in `2.0.0-dev.3.0`).
+
+* (npm) Fixed compatibility with Web Workers (was broken in `2.0.0-dev.3.0`).
+
 ## 2.0.0-dev.3.0 (January 2020)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@
 
 * (CLI) When validating a directory, the validator now additionally lists assets with errors in the end.
 
+* (CLI) Usage info and runtime errors are more accurate now.
+
 ### Bugfixes
+
+* Fixed crash on unresolved node children used in a scene (introduced in `2.0.0-dev.3.0`).
+
+* Fixed incorrect error message in `ARRAY_LENGTH_NOT_IN_LIST` for accessors of integer component type.
+
+* `ARRAY_LENGTH_NOT_IN_LIST` no longer reported for accessors of unknown type.
+
+* IBM and attribute accessor data is no longer validated when the accessors have invalid formats.
+
+* (CLI) Uncaught runtime errors no longer hang directory validation.
 
 * (CLI) Await until the report is written and flushed to disk (#126).
 

--- a/lib/cmd_line.dart
+++ b/lib/cmd_line.dart
@@ -219,7 +219,7 @@ Future<void> run(List<String> args) async {
     return;
   }
 
-  final input = File(argResult.rest[0]).absolute.path;
+  final input = p.normalize(p.absolute(argResult.rest[0]));
   ValidationOptions validationOptions;
   final validatorOptions = ValidatorOptions.fromArgs(argResult);
 
@@ -251,15 +251,13 @@ Future<void> run(List<String> args) async {
     void spawn() {
       if (it.moveNext()) {
         ++activeTasks;
-        final assetFile = it.current;
+        final assetPath = it.current.path;
         balancer
-            .run(
-                _processFileZoned,
-                ValidationTask(
-                    assetFile.path, validatorOptions, validationOptions))
+            .run(_processFileZoned,
+                ValidationTask(assetPath, validatorOptions, validationOptions))
             .then((hasErrors) {
           if (hasErrors) {
-            assetsWithErrors.add(assetFile.path);
+            assetsWithErrors.add(assetPath);
           }
         }).whenComplete(() {
           spawn();

--- a/lib/cmd_line.dart
+++ b/lib/cmd_line.dart
@@ -268,7 +268,7 @@ Future<void> run(List<String> args) async {
             if (assetsWithErrors.isNotEmpty) {
               errPipe
                 ..write('\nAssets with errors:\n')
-                ..write(assetsWithErrors.map((a) => '\t$a\n').join(''));
+                ..writeAll(assetsWithErrors.map<String>((a) => '\t$a\n'));
               exitCode = kErrorCode;
             }
           }

--- a/lib/cmd_line.dart
+++ b/lib/cmd_line.dart
@@ -329,12 +329,6 @@ Future<bool> _processFile(ValidationTask task) async {
 
   watch.stop();
 
-  final reportPath = '${task.filename}.report.json';
-
-  // ignore: unawaited_futures
-  File(reportPath).writeAsString(
-      const JsonEncoder.withIndent('    ').convert(validationResult.toMap()));
-
   final errors = validationResult.context.errors.toList(growable: false);
   final warnings = validationResult.context.warnings.toList(growable: false);
   final infos = validationResult.context.infos.toList(growable: false);
@@ -368,6 +362,10 @@ Future<bool> _processFile(ValidationTask task) async {
     }
   }
   errPipe.write(sb.toString());
+
+  await File('${task.filename}.report.json').writeAsString(
+      const JsonEncoder.withIndent('    ').convert(validationResult.toMap()),
+      flush: true);
 
   return errors.isNotEmpty;
 }

--- a/lib/src/base/accessor.dart
+++ b/lib/src/base/accessor.dart
@@ -151,15 +151,17 @@ abstract class Accessor<T extends num> extends GltfChildOfRootProperty {
     List<num> max;
     List<num> min;
     if (type != null && componentType != -1) {
-      final length = ACCESSOR_TYPES_LENGTHS[type] ?? -1;
-      if (componentType == gl.FLOAT) {
-        min = getFloatList(map, MIN, context,
-            lengthsList: [length], singlePrecision: true);
-        max = getFloatList(map, MAX, context,
-            lengthsList: [length], singlePrecision: true);
-      } else {
-        min = getGlIntList(map, MIN, context, componentType, length);
-        max = getGlIntList(map, MAX, context, componentType, length);
+      final length = ACCESSOR_TYPES_LENGTHS[type];
+      if (length != null) {
+        if (componentType == gl.FLOAT) {
+          min = getFloatList(map, MIN, context,
+              lengthsList: [length], singlePrecision: true);
+          max = getFloatList(map, MAX, context,
+              lengthsList: [length], singlePrecision: true);
+        } else {
+          min = getGlIntList(map, MIN, context, componentType, length);
+          max = getGlIntList(map, MAX, context, componentType, length);
+        }
       }
     }
 
@@ -369,7 +371,7 @@ abstract class Accessor<T extends num> extends GltfChildOfRootProperty {
                     values.byteOffset,
                     componentLength,
                     componentLength *
-                        ACCESSOR_TYPES_LENGTHS[type] *
+                        (ACCESSOR_TYPES_LENGTHS[type] ?? 0) *
                         sparse.count,
                     values._bufferView,
                     values._bufferViewIndex,
@@ -683,7 +685,9 @@ class _AccessorInt extends Accessor<int> {
           !Accessor._checkByteOffsetAndLength(
               sparse.values.byteOffset,
               componentLength,
-              componentLength * ACCESSOR_TYPES_LENGTHS[type] * sparse.count,
+              componentLength *
+                  (ACCESSOR_TYPES_LENGTHS[type] ?? 0) *
+                  sparse.count,
               sparse.values._bufferView)) {
         return;
       }
@@ -880,7 +884,9 @@ class _AccessorFloat extends Accessor<double> {
           !Accessor._checkByteOffsetAndLength(
               sparse.values.byteOffset,
               componentLength,
-              componentLength * ACCESSOR_TYPES_LENGTHS[type] * sparse.count,
+              componentLength *
+                  (ACCESSOR_TYPES_LENGTHS[type] ?? 0) *
+                  sparse.count,
               sparse.values._bufferView)) {
         return;
       }

--- a/lib/src/base/node.dart
+++ b/lib/src/base/node.dart
@@ -233,7 +233,7 @@ class Node extends GltfChildOfRootProperty {
     _scenes.add(scene);
     if (children != null) {
       for (final node in children) {
-        node.addScene(scene);
+        node?.addScene(scene);
       }
     }
   }

--- a/lib/src/base/skin.dart
+++ b/lib/src/base/skin.dart
@@ -108,15 +108,15 @@ class Skin extends GltfChildOfRootProperty {
               format,
               [SKIN_IBM_FORMAT]
             ]);
+          } else {
+            context.addElementChecker(_inverseBindMatrices,
+                IbmMatrixFloatChecker(context.getPointerString()));
           }
 
           if (_joints != null && _inverseBindMatrices.count != _joints.length) {
             context.addIssue(LinkError.invalidIbmAccessorCount,
                 args: [_joints.length, _inverseBindMatrices.count]);
           }
-
-          context.addElementChecker(_inverseBindMatrices,
-              IbmMatrixFloatChecker(context.getPointerString()));
           context.path.removeLast();
         }
       }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -398,7 +398,7 @@ List<int> getGlIntList(Map<String, Object> map, String name, Context context,
   if (value is List<Object>) {
     if (value.length != length) {
       context.addIssue(SchemaError.arrayLengthNotInList, name: name, args: [
-        value,
+        value.length,
         [length]
       ]);
       return null;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.0-dev.3.0';
+const packageVersion = '2.0.0-dev.3.1';

--- a/node/gltf_validator.dart
+++ b/node/gltf_validator.dart
@@ -177,10 +177,10 @@ Future<Map<String, Object>> _validateResourcesAndGetReport(
     final loader =
         _getResourcesLoader(context, result, externalResourceFunction);
     await loader.load(
-        validateAccessorData: options.validateAccessorData ?? true);
+        validateAccessorData: options?.validateAccessorData ?? true);
   }
   return ValidationResult(uri, context, result,
-          writeTimestamp: options.writeTimestamp ?? true)
+          writeTimestamp: options?.writeTimestamp ?? true)
       .toMap();
 }
 

--- a/node/gltf_validator.dart
+++ b/node/gltf_validator.dart
@@ -177,7 +177,7 @@ Future<Map<String, Object>> _validateResourcesAndGetReport(
     final loader =
         _getResourcesLoader(context, result, externalResourceFunction);
     await loader.load(
-        validateAccessorData: options?.validateAccessorData ?? true);
+        validateAccessorData: options.validateAccessorData ?? true);
   }
   return ValidationResult(uri, context, result,
           writeTimestamp: options?.writeTimestamp ?? true)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.3.0
+version: 2.0.0-dev.3.1
 description: Library for loading and validating glTF 2.0 assets
 author: The Khronos Group Inc.
 homepage: https://github.com/KhronosGroup/glTF-Validator

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,9 +19,9 @@ dev_dependencies:
   build_version: '^2.0.1'
   grinder: '^0.8.3+1'
   js: '^0.6.1+1'
-  node_preamble: '^1.4.8'
+  node_preamble: '1.4.8'
   resource: '^2.1.6'
-  test: '^1.9.4'
+  test: '^1.11.0'
 
 environment:
   sdk: '>=2.7.0 <3.0.0'

--- a/test/base/assets.json
+++ b/test/base/assets.json
@@ -174,6 +174,7 @@
             "integer_written_as_float.gltf": "Integer written as float",
             "invalid_sparse_count_and_stride.gltf": "Invalid sparse count and stride",
             "matrix_alignment.gltf": "Matrix alignment",
+            "unknown_type.gltf": "Unknown type",
             "small_stride.gltf": "Small stride",
             "unresolved_bufferviews.gltf": "Unresolved buffer views",
             "valid.gltf": "Valid"

--- a/test/base/assets.json
+++ b/test/base/assets.json
@@ -295,6 +295,7 @@
             "non_root_node.gltf": "Non-root node",
             "unresolved_default_scene.gltf": "Unresolved IBM accessor",
             "unresolved_node.gltf": "Unresolved joint index",
+            "unresolved_child_node.gltf": "Unresolved child node",
             "valid.gltf": "Valid"
         }
     },

--- a/test/base/data/accessor/unknown_type.gltf
+++ b/test/base/data/accessor/unknown_type.gltf
@@ -1,0 +1,37 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "accessors": [
+        {
+            "componentType": 5126,
+            "count": 24,
+            "max": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "min": [
+                -1.0,
+                -1.0,
+                -1.0
+            ],
+            "type": "NotaVEC3"
+        },
+        {
+            "componentType": 5125,
+            "count": 24,
+            "max": [
+                1,
+                1,
+                1
+            ],
+            "min": [
+                -1,
+                -1,
+                -1
+            ],
+            "type": "NotaVEC3"
+        }
+    ]
+}

--- a/test/base/data/accessor/unknown_type.gltf.report.json
+++ b/test/base/data/accessor/unknown_type.gltf.report.json
@@ -1,0 +1,53 @@
+{
+    "uri": "test/base/data/accessor/unknown_type.gltf",
+    "mimeType": "model/gltf+json",
+    "validatorVersion": "2.0.0-dev.3.1",
+    "issues": {
+        "numErrors": 0,
+        "numWarnings": 2,
+        "numInfos": 2,
+        "numHints": 0,
+        "messages": [
+            {
+                "code": "VALUE_NOT_IN_LIST",
+                "message": "Invalid value 'NotaVEC3'. Valid values are ('SCALAR', 'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', 'MAT4').",
+                "severity": 1,
+                "pointer": "/accessors/0/type"
+            },
+            {
+                "code": "VALUE_NOT_IN_LIST",
+                "message": "Invalid value 'NotaVEC3'. Valid values are ('SCALAR', 'VEC2', 'VEC3', 'VEC4', 'MAT2', 'MAT3', 'MAT4').",
+                "severity": 1,
+                "pointer": "/accessors/1/type"
+            },
+            {
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
+                "severity": 2,
+                "pointer": "/accessors/0"
+            },
+            {
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
+                "severity": 2,
+                "pointer": "/accessors/1"
+            }
+        ],
+        "truncated": false
+    },
+    "info": {
+        "version": "2.0",
+        "animationCount": 0,
+        "materialCount": 0,
+        "hasMorphTargets": false,
+        "hasSkins": false,
+        "hasTextures": false,
+        "hasDefaultScene": false,
+        "drawCallCount": 0,
+        "totalVertexCount": 0,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 0
+    }
+}

--- a/test/base/data/scene/unresolved_child_node.gltf
+++ b/test/base/data/scene/unresolved_child_node.gltf
@@ -1,0 +1,19 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "children": [
+                5
+            ]
+        }
+    ]
+}

--- a/test/base/data/scene/unresolved_child_node.gltf.report.json
+++ b/test/base/data/scene/unresolved_child_node.gltf.report.json
@@ -1,0 +1,35 @@
+{
+    "uri": "test/base/data/scene/unresolved_child_node.gltf",
+    "mimeType": "model/gltf+json",
+    "validatorVersion": "2.0.0-dev.3.1",
+    "issues": {
+        "numErrors": 1,
+        "numWarnings": 0,
+        "numInfos": 0,
+        "numHints": 0,
+        "messages": [
+            {
+                "code": "UNRESOLVED_REFERENCE",
+                "message": "Unresolved reference: 5.",
+                "severity": 0,
+                "pointer": "/nodes/0/children/0"
+            }
+        ],
+        "truncated": false
+    },
+    "info": {
+        "version": "2.0",
+        "animationCount": 0,
+        "materialCount": 0,
+        "hasMorphTargets": false,
+        "hasSkins": false,
+        "hasTextures": false,
+        "hasDefaultScene": false,
+        "drawCallCount": 0,
+        "totalVertexCount": 0,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 0
+    }
+}

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -130,6 +130,16 @@ void _npmBuild({bool release = true}) {
   delete(_nodeTargetDir);
   _runBuild(_nodeSource, release: release);
 
+  // TODO: remove this patch after upstream update
+  {
+    final file = File(p.join(_nodeTarget, 'gltf_validator.dart.js'));
+    file.writeAsStringSync(file.readAsStringSync().replaceFirst(
+        '!dartNodePreambleSelf.window',
+        '!dartNodePreambleSelf.window&&'
+            '!(\'undefined\'!==typeof WorkerGlobalScope&&'
+            'dartNodePreambleSelf instanceof WorkerGlobalScope)'));
+  }
+
   const packageJson = 'package.json';
   final jsonMap =
       json.decode(File(p.join(_nodeSource, packageJson)).readAsStringSync())


### PR DESCRIPTION
A bugfix update for the recent `2.0.0-dev.3.0` release.

### New Features

* (CLI) When validating a directory, the validator now additionally lists assets with errors in the end (improves Sample-Models CI experience).
* (CLI) Usage info and runtime errors are more accurate now.

### Bugfixes

* Fixed crash on unresolved node children used in a scene (introduced in `2.0.0-dev.3.0`).
* Fixed incorrect error message in `ARRAY_LENGTH_NOT_IN_LIST` for accessors of integer component type.
* `ARRAY_LENGTH_NOT_IN_LIST` no longer reported for accessors of unknown type.
* IBM and attribute accessor data is no longer validated when the accessors have invalid formats.
* (CLI) Uncaught runtime errors no longer hang directory validation.
* (CLI) Await until the report is written and flushed to disk (fixes #126).
* (npm) Fixed crash on missing validation options JS object (introduced in `2.0.0-dev.3.0`).
* (npm) Fixed compatibility with Web Workers (was broken in `2.0.0-dev.3.0`).