### PR TITLE
Version 2.0.0-dev.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Validating an asset with an extension that alters allowed enum values (like MIME types for images or vertex formats for accessors) no longer affects subsequent validation runs (introduced in `2.0.0-dev.3.0`).
 
+* Special characters (`~` and `/`) in JSON Pointers (RFC 6901) are now properly escaped.
+
 ## 2.0.0-dev.3.1
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-dev.3.2
+
+### Bugfixes
+
+* Validating an asset with an extension that alters allowed enum values (like MIME types for images or vertex formats for accessors) no longer affects subsequent validation runs (introduced in `2.0.0-dev.3.0`).
+
 ## 2.0.0-dev.3.1
 
 ### New Features

--- a/lib/src/base/image.dart
+++ b/lib/src/base/image.dart
@@ -42,7 +42,8 @@ class Image extends GltfChildOfRootProperty {
     }
 
     final bufferViewIndex = getIndex(map, BUFFER_VIEW, context, req: false);
-    var mimeType = getString(map, MIME_TYPE, context, list: imageMimeTypes);
+    var mimeType =
+        getString(map, MIME_TYPE, context, list: context.imageMimeTypes);
     final uriString = getString(map, URI, context, req: false);
 
     if (context.validate) {
@@ -77,9 +78,10 @@ class Image extends GltfChildOfRootProperty {
 
         // Re-assign `mimeType` only if it wasn't set in JSON
         if (mimeType == null) {
-          if (context.validate && !imageMimeTypes.contains(uriData.mimeType)) {
+          if (context.validate &&
+              !context.imageMimeTypes.contains(uriData.mimeType)) {
             context.addIssue(SchemaError.valueNotInList,
-                name: URI, args: [uriData.mimeType, imageMimeTypes]);
+                name: URI, args: [uriData.mimeType, context.imageMimeTypes]);
           }
           mimeType = uriData.mimeType;
         }

--- a/lib/src/base/members.dart
+++ b/lib/src/base/members.dart
@@ -314,9 +314,6 @@ const List<String> IMAGE_MEMBERS = <String>[BUFFER_VIEW, MIME_TYPE, URI, NAME];
 const String IMAGE_JPEG = 'image/jpeg';
 const String IMAGE_PNG = 'image/png';
 
-// Not a constant since extensions can append to it
-List<String> imageMimeTypes = <String>[IMAGE_JPEG, IMAGE_PNG];
-
 // Material
 const String PBR_METALLIC_ROUGHNESS = 'pbrMetallicRoughness';
 const String NORMAL_TEXTURE = 'normalTexture';
@@ -479,42 +476,6 @@ const List<String> ATTRIBUTE_SEMANTIC_ARRAY_MEMBERS = <String>[
   TEXCOORD_,
   WEIGHTS_
 ];
-
-Map<String, Set<AccessorFormat>> attributeAccessorFormats =
-    <String, Set<AccessorFormat>>{
-  POSITION: {const AccessorFormat(VEC3, gl.FLOAT)},
-  NORMAL: {const AccessorFormat(VEC3, gl.FLOAT)},
-  TANGENT: {const AccessorFormat(VEC4, gl.FLOAT)},
-  TEXCOORD_: {
-    const AccessorFormat(VEC2, gl.FLOAT),
-    const AccessorFormat(VEC2, gl.UNSIGNED_BYTE, normalized: true),
-    const AccessorFormat(VEC2, gl.UNSIGNED_SHORT, normalized: true)
-  },
-  COLOR_: {
-    const AccessorFormat(VEC3, gl.FLOAT),
-    const AccessorFormat(VEC3, gl.UNSIGNED_BYTE, normalized: true),
-    const AccessorFormat(VEC3, gl.UNSIGNED_SHORT, normalized: true),
-    const AccessorFormat(VEC4, gl.FLOAT),
-    const AccessorFormat(VEC4, gl.UNSIGNED_BYTE, normalized: true),
-    const AccessorFormat(VEC4, gl.UNSIGNED_SHORT, normalized: true)
-  },
-  JOINTS_: {
-    const AccessorFormat(VEC4, gl.UNSIGNED_BYTE),
-    const AccessorFormat(VEC4, gl.UNSIGNED_SHORT)
-  },
-  WEIGHTS_: {
-    const AccessorFormat(VEC4, gl.FLOAT),
-    const AccessorFormat(VEC4, gl.UNSIGNED_BYTE, normalized: true),
-    const AccessorFormat(VEC4, gl.UNSIGNED_SHORT, normalized: true)
-  }
-};
-
-Map<String, Set<AccessorFormat>> morphAttributeAccessorFormats =
-    <String, Set<AccessorFormat>>{
-  POSITION: {const AccessorFormat(VEC3, gl.FLOAT)},
-  NORMAL: {const AccessorFormat(VEC3, gl.FLOAT)},
-  TANGENT: {const AccessorFormat(VEC3, gl.FLOAT)},
-};
 
 const Map<int, String> ATTRIBUTE_TYPES = <int, String>{
   gl.FLOAT: SCALAR,

--- a/lib/src/base/mesh.dart
+++ b/lib/src/base/mesh.dart
@@ -279,7 +279,7 @@ class MeshPrimitive extends GltfProperty {
     }
 
     void checkMorphTargetAttributeSemanticName(String semantic) {
-      if (!morphAttributeAccessorFormats.containsKey(semantic) &&
+      if (!context.morphAttributeAccessorFormats.containsKey(semantic) &&
           !semantic.startsWith('_')) {
         context.addIssue(SemanticError.meshPrimitiveInvalidAttribute,
             name: semantic);
@@ -356,7 +356,8 @@ class MeshPrimitive extends GltfProperty {
           }
 
           final format = AccessorFormat.fromAccessor(accessor);
-          final validFormats = attributeAccessorFormats[semantic.split('_')[0]];
+          final validFormats =
+              context.attributeAccessorFormats[semantic.split('_')[0]];
           if (validFormats != null) {
             if (!validFormats.contains(format)) {
               context.addIssue(
@@ -569,7 +570,8 @@ class MeshPrimitive extends GltfProperty {
               }
 
               final format = AccessorFormat.fromAccessor(accessor);
-              final validFormats = morphAttributeAccessorFormats[semantic];
+              final validFormats =
+                  context.morphAttributeAccessorFormats[semantic];
 
               if (validFormats != null && !validFormats.contains(format)) {
                 context.addIssue(

--- a/lib/src/base/mesh.dart
+++ b/lib/src/base/mesh.dart
@@ -519,8 +519,10 @@ class MeshPrimitive extends GltfProperty {
       }
 
       for (final unusedIndex in unusedTexCoords.where((i) => i != -1)) {
-        context.addIssue(LinkError.unusedObject,
-            name: '$ATTRIBUTES/${TEXCOORD_}_$unusedIndex');
+        context
+          ..path.add(ATTRIBUTES)
+          ..addIssue(LinkError.unusedObject, name: '${TEXCOORD_}_$unusedIndex')
+          ..path.removeLast();
       }
     }
 

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -140,7 +140,9 @@ class Context {
     _sb
       ..write('/')
       ..writeAll(
-          path.map((s) => s.replaceAll('~', '~0').replaceAll('/', '~1')), '/');
+          path.map<String>(
+              (s) => s.replaceAll('~', '~0').replaceAll('/', '~1')),
+          '/');
 
     if (token != null) {
       path.removeLast();

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -21,6 +21,7 @@ import 'dart:collection';
 import 'package:gltf/src/base/gltf_property.dart';
 import 'package:gltf/src/errors.dart';
 import 'package:gltf/src/ext/extensions.dart';
+import 'package:gltf/src/gl.dart' as gl;
 
 class ValidationOptions {
   final int maxIssues;
@@ -191,7 +192,7 @@ class Context {
       });
 
       if (extension.init != null) {
-        extension.init();
+        extension.init(this);
       }
 
       if (validate &&
@@ -253,6 +254,44 @@ class Context {
   void setGlb() {
     _isGlb = true;
   }
+
+  final List<String> imageMimeTypes = <String>[IMAGE_JPEG, IMAGE_PNG];
+
+  final Map<String, Set<AccessorFormat>> attributeAccessorFormats =
+      <String, Set<AccessorFormat>>{
+    POSITION: {const AccessorFormat(VEC3, gl.FLOAT)},
+    NORMAL: {const AccessorFormat(VEC3, gl.FLOAT)},
+    TANGENT: {const AccessorFormat(VEC4, gl.FLOAT)},
+    TEXCOORD_: {
+      const AccessorFormat(VEC2, gl.FLOAT),
+      const AccessorFormat(VEC2, gl.UNSIGNED_BYTE, normalized: true),
+      const AccessorFormat(VEC2, gl.UNSIGNED_SHORT, normalized: true)
+    },
+    COLOR_: {
+      const AccessorFormat(VEC3, gl.FLOAT),
+      const AccessorFormat(VEC3, gl.UNSIGNED_BYTE, normalized: true),
+      const AccessorFormat(VEC3, gl.UNSIGNED_SHORT, normalized: true),
+      const AccessorFormat(VEC4, gl.FLOAT),
+      const AccessorFormat(VEC4, gl.UNSIGNED_BYTE, normalized: true),
+      const AccessorFormat(VEC4, gl.UNSIGNED_SHORT, normalized: true)
+    },
+    JOINTS_: {
+      const AccessorFormat(VEC4, gl.UNSIGNED_BYTE),
+      const AccessorFormat(VEC4, gl.UNSIGNED_SHORT)
+    },
+    WEIGHTS_: {
+      const AccessorFormat(VEC4, gl.FLOAT),
+      const AccessorFormat(VEC4, gl.UNSIGNED_BYTE, normalized: true),
+      const AccessorFormat(VEC4, gl.UNSIGNED_SHORT, normalized: true)
+    }
+  };
+
+  final Map<String, Set<AccessorFormat>> morphAttributeAccessorFormats =
+      <String, Set<AccessorFormat>>{
+    POSITION: {const AccessorFormat(VEC3, gl.FLOAT)},
+    NORMAL: {const AccessorFormat(VEC3, gl.FLOAT)},
+    TANGENT: {const AccessorFormat(VEC3, gl.FLOAT)},
+  };
 }
 
 class IssuesLimitExceededException implements Exception {

--- a/lib/src/data_access/resources_loader.dart
+++ b/lib/src/data_access/resources_loader.dart
@@ -211,7 +211,7 @@ class ResourcesLoader {
         try {
           imageInfo = await ImageInfo.parseStreamAsync(imageDataStream);
           if (context.validate &&
-              !imageMimeTypes.contains(imageInfo.mimeType)) {
+              !context.imageMimeTypes.contains(imageInfo.mimeType)) {
             context.addIssue(DataError.imageNonEnabledMimeType,
                 args: [imageInfo.mimeType]);
           }

--- a/lib/src/ext/EXT_texture_webp/ext_texture_webp.dart
+++ b/lib/src/ext/EXT_texture_webp/ext_texture_webp.dart
@@ -26,8 +26,8 @@ const Extension extTextureWebPExtension = Extension('EXT_texture_webp',
     <Type, ExtFuncs>{Texture: ExtFuncs(ExtTextureWebPTexture.fromMap)},
     init: _init);
 
-void _init() {
-  imageMimeTypes.add(IMAGE_WEBP);
+void _init(Context context) {
+  context.imageMimeTypes.add(IMAGE_WEBP);
 }
 
 const List<String> EXT_TEXTURE_WEBP_TEXTURE_MEMBERS = <String>[SOURCE];

--- a/lib/src/ext/KHR_mesh_quantization/khr_mesh_quantization.dart
+++ b/lib/src/ext/KHR_mesh_quantization/khr_mesh_quantization.dart
@@ -22,8 +22,8 @@ import 'package:gltf/src/gl.dart' as gl;
 
 const String KHR_MESH_QUANTIZATION = 'KHR_mesh_quantization';
 
-void _init() {
-  attributeAccessorFormats[POSITION].addAll(const [
+void _init(Context context) {
+  context.attributeAccessorFormats[POSITION].addAll(const [
     AccessorFormat(VEC3, gl.BYTE),
     AccessorFormat(VEC3, gl.BYTE, normalized: true),
     AccessorFormat(VEC3, gl.UNSIGNED_BYTE),
@@ -34,17 +34,17 @@ void _init() {
     AccessorFormat(VEC3, gl.UNSIGNED_SHORT, normalized: true)
   ]);
 
-  attributeAccessorFormats[NORMAL].addAll(const [
+  context.attributeAccessorFormats[NORMAL].addAll(const [
     AccessorFormat(VEC3, gl.BYTE, normalized: true),
     AccessorFormat(VEC3, gl.SHORT, normalized: true)
   ]);
 
-  attributeAccessorFormats[TANGENT].addAll(const [
+  context.attributeAccessorFormats[TANGENT].addAll(const [
     AccessorFormat(VEC4, gl.BYTE, normalized: true),
     AccessorFormat(VEC4, gl.SHORT, normalized: true)
   ]);
 
-  attributeAccessorFormats[TEXCOORD_].addAll(const [
+  context.attributeAccessorFormats[TEXCOORD_].addAll(const [
     AccessorFormat(VEC2, gl.BYTE),
     AccessorFormat(VEC2, gl.BYTE, normalized: true),
     AccessorFormat(VEC2, gl.UNSIGNED_BYTE),
@@ -53,19 +53,19 @@ void _init() {
     AccessorFormat(VEC2, gl.UNSIGNED_SHORT)
   ]);
 
-  morphAttributeAccessorFormats[POSITION].addAll(const [
+  context.morphAttributeAccessorFormats[POSITION].addAll(const [
     AccessorFormat(VEC3, gl.BYTE),
     AccessorFormat(VEC3, gl.BYTE, normalized: true),
     AccessorFormat(VEC3, gl.SHORT),
     AccessorFormat(VEC3, gl.SHORT, normalized: true)
   ]);
 
-  morphAttributeAccessorFormats[NORMAL].addAll(const [
+  context.morphAttributeAccessorFormats[NORMAL].addAll(const [
     AccessorFormat(VEC3, gl.BYTE, normalized: true),
     AccessorFormat(VEC3, gl.SHORT, normalized: true)
   ]);
 
-  morphAttributeAccessorFormats[TANGENT].addAll(const [
+  context.morphAttributeAccessorFormats[TANGENT].addAll(const [
     AccessorFormat(VEC3, gl.BYTE, normalized: true),
     AccessorFormat(VEC3, gl.SHORT, normalized: true)
   ]);

--- a/lib/src/ext/extensions.dart
+++ b/lib/src/ext/extensions.dart
@@ -40,7 +40,7 @@ class Extension {
 
   final String name;
   final Map<Type, ExtFuncs> functions;
-  final void Function() init;
+  final void Function(Context) init;
   final bool required;
 }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.0-dev.3.1';
+const packageVersion = '2.0.0-dev.3.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.3.1
+version: 2.0.0-dev.3.2
 description: Library for loading and validating glTF 2.0 assets
 author: The Khronos Group Inc.
 homepage: https://github.com/KhronosGroup/glTF-Validator

--- a/test/base/assets.json
+++ b/test/base/assets.json
@@ -205,6 +205,7 @@
             "indices_bytestride.gltf": "Indices accessor with byte stride",
             "indices_invalid_format.gltf": "Indices accessor invalid format",
             "invalid_attribute.gltf": "Invalid attribute",
+            "invalid_attribute_escaped_name.gltf": "Invalid attribute with special chars",
             "invalid_indexed_attribute.gltf": "Invalid indexed attribute",
             "invalid_tangent.gltf": "Invalid tangent",
             "morph_attribute_invalid_count.gltf": "Morph attribute invalid count",
@@ -332,6 +333,8 @@
     "root": {
         "name": "Root glTF object",
         "tests": {
+            "custom_property.gltf": "Custom property",
+            "custom_property_escaped_name.gltf": "Custom property with special chars",
             "duplicate_extension_entry.gltf": "Duplicate extension entry",
             "empty_object.gltf": "Empty object",
             "extensions_non_objects.gltf": "Non-object extensions",

--- a/test/base/data/mesh/invalid_attribute_escaped_name.gltf
+++ b/test/base/data/mesh/invalid_attribute_escaped_name.gltf
@@ -1,0 +1,41 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "meshes": [
+        {
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0,
+                        "~UNKNOWN/2": 1
+                    },
+                    "targets": [
+                        {
+                            "~UNKNOWN/2": 2
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "type": "VEC3",
+            "componentType": 5126,
+            "count": 3,
+            "min": [0, 0, 0],
+            "max": [1, 1, 1]
+        },
+        {
+            "type": "VEC2",
+            "componentType": 5126,
+            "count": 3
+        },
+        {
+            "type": "VEC2",
+            "componentType": 5126,
+            "count": 3
+        }
+    ]
+}

--- a/test/base/data/mesh/invalid_attribute_escaped_name.gltf.report.json
+++ b/test/base/data/mesh/invalid_attribute_escaped_name.gltf.report.json
@@ -1,0 +1,47 @@
+{
+    "uri": "test/base/data/mesh/invalid_attribute_escaped_name.gltf",
+    "mimeType": "model/gltf+json",
+    "validatorVersion": "2.0.0-dev.3.2",
+    "issues": {
+        "numErrors": 2,
+        "numWarnings": 0,
+        "numInfos": 1,
+        "numHints": 0,
+        "messages": [
+            {
+                "code": "MESH_PRIMITIVE_INVALID_ATTRIBUTE",
+                "message": "Invalid attribute name.",
+                "severity": 0,
+                "pointer": "/meshes/0/primitives/0/attributes/~0UNKNOWN~12"
+            },
+            {
+                "code": "MESH_PRIMITIVE_INVALID_ATTRIBUTE",
+                "message": "Invalid attribute name.",
+                "severity": 0,
+                "pointer": "/meshes/0/primitives/0/targets/0/~0UNKNOWN~12"
+            },
+            {
+                "code": "UNUSED_OBJECT",
+                "message": "This object may be unused.",
+                "severity": 2,
+                "pointer": "/meshes/0"
+            }
+        ],
+        "truncated": false
+    },
+    "info": {
+        "version": "2.0",
+        "animationCount": 0,
+        "materialCount": 0,
+        "hasMorphTargets": true,
+        "hasSkins": false,
+        "hasTextures": false,
+        "hasDefaultScene": false,
+        "drawCallCount": 1,
+        "totalVertexCount": 3,
+        "totalTriangleCount": 1,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 2
+    }
+}

--- a/test/base/data/root/custom_property.gltf
+++ b/test/base/data/root/custom_property.gltf
@@ -1,0 +1,6 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "customProperty": true
+}

--- a/test/base/data/root/custom_property.gltf.report.json
+++ b/test/base/data/root/custom_property.gltf.report.json
@@ -1,0 +1,35 @@
+{
+    "uri": "test/base/data/root/custom_property.gltf",
+    "mimeType": "model/gltf+json",
+    "validatorVersion": "2.0.0-dev.3.2",
+    "issues": {
+        "numErrors": 0,
+        "numWarnings": 1,
+        "numInfos": 0,
+        "numHints": 0,
+        "messages": [
+            {
+                "code": "UNEXPECTED_PROPERTY",
+                "message": "Unexpected property.",
+                "severity": 1,
+                "pointer": "/customProperty"
+            }
+        ],
+        "truncated": false
+    },
+    "info": {
+        "version": "2.0",
+        "animationCount": 0,
+        "materialCount": 0,
+        "hasMorphTargets": false,
+        "hasSkins": false,
+        "hasTextures": false,
+        "hasDefaultScene": false,
+        "drawCallCount": 0,
+        "totalVertexCount": 0,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 0
+    }
+}

--- a/test/base/data/root/custom_property_escaped_name.gltf
+++ b/test/base/data/root/custom_property_escaped_name.gltf
@@ -1,0 +1,6 @@
+{
+    "asset": {
+        "version": "2.0"
+    },
+    "asset/customProperty": true
+}

--- a/test/base/data/root/custom_property_escaped_name.gltf.report.json
+++ b/test/base/data/root/custom_property_escaped_name.gltf.report.json
@@ -1,0 +1,35 @@
+{
+    "uri": "test/base/data/root/custom_property_escaped_name.gltf",
+    "mimeType": "model/gltf+json",
+    "validatorVersion": "2.0.0-dev.3.2",
+    "issues": {
+        "numErrors": 0,
+        "numWarnings": 1,
+        "numInfos": 0,
+        "numHints": 0,
+        "messages": [
+            {
+                "code": "UNEXPECTED_PROPERTY",
+                "message": "Unexpected property.",
+                "severity": 1,
+                "pointer": "/asset~1customProperty"
+            }
+        ],
+        "truncated": false
+    },
+    "info": {
+        "version": "2.0",
+        "animationCount": 0,
+        "materialCount": 0,
+        "hasMorphTargets": false,
+        "hasSkins": false,
+        "hasTextures": false,
+        "hasDefaultScene": false,
+        "drawCallCount": 0,
+        "totalVertexCount": 0,
+        "totalTriangleCount": 0,
+        "maxUVs": 0,
+        "maxInfluences": 0,
+        "maxAttributes": 0
+    }
+}


### PR DESCRIPTION
### Bugfixes

* Validating an asset with an extension that alters allowed enum values (like MIME types for images or vertex formats for accessors) no longer affects subsequent validation runs (introduced in `2.0.0-dev.3.0`).

---

This bug could have been observed only _after_ validating assets with `EXT_texture_webp` or `KHR_mesh_quantization` extensions.

/cc @zeux