### PR TITLE
Nuget package, first commit

### DIFF
--- a/nuget/ValidationContext.cs
+++ b/nuget/ValidationContext.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace glTF2Validator
+{
+    /// <summary>
+    /// Represents the context used to validate files
+    /// </summary>
+    public class ValidationContext
+    {
+        /// <summary>
+        /// Path to the gltf-validator command line executable (platform specific).
+        /// </summary>
+        public static string ValidatorExePath { get; set; }
+
+        /// <summary>
+        /// Timeout to cancel the validation operation.
+        /// </summary>
+        public static TimeSpan TimeOut { get; set; } = TimeSpan.FromSeconds(10);
+        
+        static ValidationContext()
+        {
+            SetDefaultPath();
+        }
+
+        
+        private static void SetDefaultPath()
+        {
+            var assemblyDir = System.IO.Path.GetDirectoryName(typeof(ValidationContext).Assembly.Location);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                if (RuntimeInformation.OSArchitecture != Architecture.X64) return;
+                ValidatorExePath = System.IO.Path.Combine(assemblyDir, "gltf_validator.exe");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ValidatorExePath = System.IO.Path.Combine(assemblyDir, "gltf_validator");
+            }
+        }
+        
+        /// <summary>
+        /// Validates a glTF file.
+        /// </summary>
+        /// <param name="gltfFilePath">Path to the glTF file.</param>
+        /// <returns>A report.</returns>
+        public static ValidationReport ValidateFile(string gltfFilePath)
+        {
+            if (string.IsNullOrWhiteSpace(ValidatorExePath)) return null;
+
+            if (!System.IO.File.Exists(ValidatorExePath)) throw new System.IO.FileNotFoundException(ValidatorExePath);
+
+            if (!System.IO.Path.IsPathRooted(gltfFilePath)) gltfFilePath = System.IO.Path.GetFullPath(gltfFilePath);
+
+            var psi = new System.Diagnostics.ProcessStartInfo(ValidatorExePath);
+            psi.Arguments = $"-p -r -a \"{gltfFilePath}\"";
+            psi.UseShellExecute = false;
+            psi.RedirectStandardError = true;
+
+            var p = System.Diagnostics.Process.Start(psi);
+
+            if (!p.WaitForExit(TimeOut.Milliseconds))
+            {
+                try { p.Kill(); } catch { }
+            }
+
+            var rawReport = p.StandardError.ReadToEnd();
+
+            if (string.IsNullOrWhiteSpace(rawReport)) return null;
+
+            return new ValidationReport(gltfFilePath, rawReport);
+        }
+    }
+}

--- a/nuget/ValidationContext.cs
+++ b/nuget/ValidationContext.cs
@@ -56,9 +56,9 @@ namespace glTF2Validator
             if (!System.IO.Path.IsPathRooted(gltfFilePath)) gltfFilePath = System.IO.Path.GetFullPath(gltfFilePath);
 
             var psi = new System.Diagnostics.ProcessStartInfo(ValidatorExePath);
-            psi.Arguments = $"-p -r -a \"{gltfFilePath}\"";
+            psi.Arguments = $"-p -r -a -o \"{gltfFilePath}\"";
             psi.UseShellExecute = false;
-            psi.RedirectStandardError = true;
+            psi.RedirectStandardOutput = true;
 
             using (var p = System.Diagnostics.Process.Start(psi))
             {
@@ -67,11 +67,11 @@ namespace glTF2Validator
                     try { p.Kill(); } catch { }
                 }
 
-                var rawReport = p.StandardError.ReadToEnd();
+                var jsonReport = p.StandardOutput.ReadToEnd();
 
-                if (string.IsNullOrWhiteSpace(rawReport)) return null;
+                if (string.IsNullOrWhiteSpace(jsonReport)) return null;
 
-                return new ValidationReport(gltfFilePath, rawReport);
+                return ValidationReport.Parse(jsonReport);
             }
         }
     }

--- a/nuget/ValidationResult.cs
+++ b/nuget/ValidationResult.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace glTF2Validator
 {
@@ -9,64 +11,49 @@ namespace glTF2Validator
     /// </summary>
     public sealed class ValidationReport
     {
-        internal ValidationReport(string srcPath, string rawReport)
+        public static ValidationReport Parse(string json)
         {
-            var lines = rawReport.Split('\n');
-
-            var status = 0;
-
-            var www = new List<string>();
-            var eee = new List<string>();
-
-            foreach (var l in lines)
+            var options = new JsonSerializerOptions
             {
-                if (l == "\tWarnings:") { status = 1; continue; }
-                if (l == "\tErrors:") { status = 2; continue; }
+                AllowTrailingCommas = true
+            };
 
-                if (status == 1) www.Add(l.Trim());
-                if (status == 2) eee.Add(l.Trim());
-            }
-
-            FilePath = srcPath;
-            RawReport = rawReport;
-            Warnings = www;
-            Errors = eee;
+            return JsonSerializer.Deserialize<ValidationReport>(json, options);
         }
 
-        /// <summary>
-        /// Gets the file path from which this report was originated.
-        /// </summary>
-        public string FilePath { get; private set; }
+        public string uri { get; set; }
+        public string mimeType { get; set; }
+        public string validatorVersion { get; set; }
 
-        /// <summary>
-        /// Gets the original report as emitted by gltf-validator.
-        /// </summary>
-        public string RawReport { get; private set; }
+        public ValidationIssues issues { get; set; }
 
-        /// <summary>
-        /// Gets the warnings as a list.
-        /// </summary>
-        public IReadOnlyList<String> Warnings { get; private set; }
+        public ValidationInfo info { get; set; }
+    }
 
-        /// <summary>
-        /// Gets the errors as a list.
-        /// </summary>
-        public IReadOnlyList<String> Errors { get; private set; }
+    public sealed class ValidationIssues
+    {
+        public int numErrors { get; set; }
+        public int numWarnings { get; set; }
+        public int numInfos { get; set; }
+        public int numHints { get; set; }
+        public string[] messages { get; set; }
+        public bool truncated { get; set; }
+    }
 
-        
-        /// <summary>
-        /// True if warnings were found.
-        /// </summary>
-        public bool HasWarnings => Warnings.Count > 0;
-
-        /// <summary>
-        /// True if errors were found.
-        /// </summary>
-        public bool HasErrors => Errors.Count > 0;
-
-        public override string ToString()
-        {
-            return RawReport;
-        }
+    public sealed class ValidationInfo
+    {
+        public string version { get; set; }
+        public string generator { get; set; }
+        public int animationCount { get; set; }
+        public int materialCount { get; set; }
+        public bool hasMorphTargets { get; set; }
+        public bool hasSkins { get; set; }
+        public bool hasTextures { get; set; }
+        public bool hasDefaultScene { get; set; }
+        public int drawCallCount { get; set; }
+        public int totalTriangleCount { get; set; }
+        public int maxUVs { get; set; }
+        public int maxInfluences { get; set; }
+        public int maxAttributes { get; set; }
     }
 }

--- a/nuget/ValidationResult.cs
+++ b/nuget/ValidationResult.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace glTF2Validator
+{
+    /// <summary>
+    /// Represents the resulting report of a glTF validation.
+    /// </summary>
+    public sealed class ValidationReport
+    {
+        internal ValidationReport(string srcPath, string rawReport)
+        {
+            var lines = rawReport.Split('\n');
+
+            var status = 0;
+
+            var www = new List<string>();
+            var eee = new List<string>();
+
+            foreach (var l in lines)
+            {
+                if (l == "\tWarnings:") { status = 1; continue; }
+                if (l == "\tErrors:") { status = 2; continue; }
+
+                if (status == 1) www.Add(l.Trim());
+                if (status == 2) eee.Add(l.Trim());
+            }
+
+            FilePath = srcPath;
+            RawReport = rawReport;
+            Warnings = www;
+            Errors = eee;
+        }
+
+        /// <summary>
+        /// Gets the file path from which this report was originated.
+        /// </summary>
+        public string FilePath { get; private set; }
+
+        /// <summary>
+        /// Gets the original report as emitted by gltf-validator.
+        /// </summary>
+        public string RawReport { get; private set; }
+
+        /// <summary>
+        /// Gets the warnings as a list.
+        /// </summary>
+        public IReadOnlyList<String> Warnings { get; private set; }
+
+        /// <summary>
+        /// Gets the errors as a list.
+        /// </summary>
+        public IReadOnlyList<String> Errors { get; private set; }
+
+        
+        /// <summary>
+        /// True if warnings were found.
+        /// </summary>
+        public bool HasWarnings => Warnings.Count > 0;
+
+        /// <summary>
+        /// True if errors were found.
+        /// </summary>
+        public bool HasErrors => Errors.Count > 0;
+
+        public override string ToString()
+        {
+            return RawReport;
+        }
+    }
+}

--- a/nuget/ValidationResult.cs
+++ b/nuget/ValidationResult.cs
@@ -13,12 +13,7 @@ namespace glTF2Validator
     {
         public static ValidationReport Parse(string json)
         {
-            var options = new JsonSerializerOptions
-            {
-                AllowTrailingCommas = true
-            };
-
-            return JsonSerializer.Deserialize<ValidationReport>(json, options);
+            return JsonSerializer.Deserialize<ValidationReport>(json);
         }
 
         public string uri { get; set; }

--- a/nuget/glTF2Validator.csproj
+++ b/nuget/glTF2Validator.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    
+    <RepositoryUrl>https://github.com/KhronosGroup/glTF-Validator</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/KhronosGroup/glTF-Validator</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <DocumentationFile>bin\$(Configuration)\$(AssemblyName).xml</DocumentationFile>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+
+  <ItemGroup>
+    <!-- These files must exist before compiling this library -->
+    <Content Include="..\build\bin\gltf_validator.exe" Link="gltf_validator.exe" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="..\build\bin\gltf_validator" Link="gltf_validator" CopyToOutputDirectory="PreserveNewest" />    
+  </ItemGroup>
+
+</Project>

--- a/nuget/glTF2Validator.csproj
+++ b/nuget/glTF2Validator.csproj
@@ -22,4 +22,9 @@
     <Content Include="..\build\bin\gltf_validator" Link="gltf_validator" CopyToOutputDirectory="PreserveNewest" />    
   </ItemGroup>
 
+
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/nuget/glTF2Validator.sln
+++ b/nuget/glTF2Validator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "glTF2Validator", "glTF2Validator.csproj", "{23B861FB-AC5B-4F01-93A0-833E2D6115A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{23B861FB-AC5B-4F01-93A0-833E2D6115A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23B861FB-AC5B-4F01-93A0-833E2D6115A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23B861FB-AC5B-4F01-93A0-833E2D6115A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23B861FB-AC5B-4F01-93A0-833E2D6115A6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {AACDACB0-9EC4-4195-A00D-54688E633E03}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
As discussed in #134, In this pull request I dropped the basic idea of a nuget package.

Its basic usage would be this:

```c#
var report = glTF2Validator.ValidationContext.ValidateFile("somefile.gltf");

if (report.HasErrors) throw new Exception(report.RawReport);
```

In order to compile the project, it is required to compile the CLI tools beforehand, since they're embedded in the nuget package.

I have only tested the Windows path; theoretically it should work on Linux, but someone will need to do the testing.

I haven't defined anything for the semantic versioning. Ideally, the nuget package should have the same version ID as the gltf-validator itself.