### PR TITLE
Fix AnimationDuplicateTargets

### DIFF
--- a/lib/src/base/animation.dart
+++ b/lib/src/base/animation.dart
@@ -346,7 +346,7 @@ class AnimationChannelTarget extends GltfProperty {
   }
 
   bool isSameAs(AnimationChannelTarget other) =>
-      other != null && _nodeIndex == other._nodeIndex && path == other.path;
+      other != null && _nodeIndex != -1 && _nodeIndex == other._nodeIndex && path == other.path;
 }
 
 class AnimationSampler extends GltfProperty {

--- a/lib/src/base/animation.dart
+++ b/lib/src/base/animation.dart
@@ -346,7 +346,10 @@ class AnimationChannelTarget extends GltfProperty {
   }
 
   bool isSameAs(AnimationChannelTarget other) =>
-      other != null && _nodeIndex != -1 && _nodeIndex == other._nodeIndex && path == other.path;
+      other != null &&
+      _nodeIndex != -1 &&
+      _nodeIndex == other._nodeIndex &&
+      path == other.path;
 }
 
 class AnimationSampler extends GltfProperty {


### PR DESCRIPTION
When the animationTarget's node is undefined, it shouldn't check for the same.

