### PR TITLE
Version 2.0.0-dev.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0-dev.3.9
+
+### Bugfixes
+
+* Fixed false positive `ANIMATION_DUPLICATE_TARGETS` caused by animation targets without `node` (#190).
+
+* Fixed false positive `ANIMATION_SAMPLER_OUTPUT_ACCESSOR_INVALID_COUNT` caused by animation targets with unknown `path`.
+
 ## 2.0.0-dev.3.8
 
 ### New Features

--- a/lib/src/base/animation.dart
+++ b/lib/src/base/animation.dart
@@ -254,6 +254,9 @@ class Animation extends GltfChildOfRootProperty {
                   final targetsCount = channel
                       .target._node?.mesh?.primitives?.first?.targets?.length;
                   expectedCount *= targetsCount ?? 0;
+                } else if (!ANIMATION_CHANNEL_TARGET_PATHS
+                    .contains(channel.target.path)) {
+                  expectedCount = 0;
                 }
 
                 if (expectedCount != 0 &&

--- a/lib/src/base/animation.dart
+++ b/lib/src/base/animation.dart
@@ -346,7 +346,10 @@ class AnimationChannelTarget extends GltfProperty {
   }
 
   bool isSameAs(AnimationChannelTarget other) =>
-      other != null && _nodeIndex == other._nodeIndex && path == other.path;
+      other != null &&
+      _nodeIndex != -1 &&
+      _nodeIndex == other._nodeIndex &&
+      path == other.path;
 }
 
 class AnimationSampler extends GltfProperty {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.0-dev.3.8';
+const packageVersion = '2.0.0-dev.3.9';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,25 +1,25 @@
 name: gltf
-version: 2.0.0-dev.3.8
+version: 2.0.0-dev.3.9
 description: Library for loading and validating glTF 2.0 assets
 homepage: https://github.com/KhronosGroup/glTF-Validator
 
 dependencies:
-  args: '^2.3.0'
+  args: '^2.3.1'
   isolate: '^2.1.1'
-  meta: '^1.7.0'
-  path: '^1.8.1'
+  meta: '^1.8.0'
+  path: '^1.8.2'
   vector_math: '^2.1.2'
-  yaml: '^3.1.0'
+  yaml: '^3.1.1'
 
 dev_dependencies:
   archive: '^3.3.0'
-  build_runner: '^2.1.10'
+  build_runner: '^2.1.11'
   build_version: '^2.1.1'
   build_web_compilers: '^3.2.3'
   grinder: '^0.9.1'
   js: '^0.6.4'
   node_preamble: '^2.0.1'
-  test: '^1.21.1'
+  test: '^1.21.2'
 
 environment:
   sdk: '>=2.11.99 <3.0.0'

--- a/test/base/data/animation/channel_duplicate_targets.gltf
+++ b/test/base/data/animation/channel_duplicate_targets.gltf
@@ -26,6 +26,28 @@
                     "sampler": 0
                 }
             ]
+        },
+        {
+            "samplers": [
+                {
+                    "input": 0,
+                    "output": 1
+                }
+            ],
+            "channels": [
+                {
+                    "target": {
+                        "path": "scale"
+                    },
+                    "sampler": 0
+                },
+                {
+                    "target": {
+                        "path": "scale"
+                    },
+                    "sampler": 0
+                }
+            ]
         }
     ],
     "nodes": [

--- a/test/base/data/animation/channel_duplicate_targets.gltf.report.json
+++ b/test/base/data/animation/channel_duplicate_targets.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/base/data/animation/channel_duplicate_targets.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.0",
+    "validatorVersion": "2.0.0-dev.3.9",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,
@@ -19,7 +19,7 @@
     },
     "info": {
         "version": "2.0",
-        "animationCount": 1,
+        "animationCount": 2,
         "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,

--- a/test/base/data/animation/sampler_output_count_invalid.gltf
+++ b/test/base/data/animation/sampler_output_count_invalid.gltf
@@ -19,6 +19,22 @@
                     "sampler": 0
                 }
             ]
+        },
+        {
+            "samplers": [
+                {
+                    "input": 0,
+                    "output": 2
+                }
+            ],
+            "channels": [
+                {
+                    "target": {
+                        "path": "unknown"
+                    },
+                    "sampler": 0
+                }
+            ]
         }
     ],
     "nodes": [
@@ -40,6 +56,11 @@
             "type": "VEC3",
             "componentType": 5126,
             "count": 2
+        },
+        {
+            "type": "VEC3",
+            "componentType": 5126,
+            "count": 3
         }
     ]
 }

--- a/test/base/data/animation/sampler_output_count_invalid.gltf.report.json
+++ b/test/base/data/animation/sampler_output_count_invalid.gltf.report.json
@@ -1,13 +1,19 @@
 {
     "uri": "test/base/data/animation/sampler_output_count_invalid.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.0",
+    "validatorVersion": "2.0.0-dev.3.9",
     "issues": {
         "numErrors": 1,
-        "numWarnings": 0,
+        "numWarnings": 1,
         "numInfos": 0,
         "numHints": 0,
         "messages": [
+            {
+                "code": "VALUE_NOT_IN_LIST",
+                "message": "Invalid value 'unknown'. Valid values are ('translation', 'rotation', 'scale', 'weights').",
+                "severity": 1,
+                "pointer": "/animations/1/channels/0/target/path"
+            },
             {
                 "code": "ANIMATION_SAMPLER_OUTPUT_ACCESSOR_INVALID_COUNT",
                 "message": "Animation sampler output accessor of count 1 expected. Found 2.",
@@ -19,7 +25,7 @@
     },
     "info": {
         "version": "2.0",
-        "animationCount": 1,
+        "animationCount": 2,
         "materialCount": 0,
         "hasMorphTargets": false,
         "hasSkins": false,


### PR DESCRIPTION
## 2.0.0-dev.3.9

### Bugfixes

* Fixed false positive `ANIMATION_DUPLICATE_TARGETS` caused by animation targets without `node` (#190).

* Fixed false positive `ANIMATION_SAMPLER_OUTPUT_ACCESSOR_INVALID_COUNT` caused by animation targets with unknown `path`.

---

/cc @hybridherbst