### PR TITLE
Color and Texcoord are supported for morphs

### DIFF
--- a/lib/src/base/mesh.dart
+++ b/lib/src/base/mesh.dart
@@ -289,6 +289,11 @@ class MeshPrimitive extends GltfProperty {
     }
 
     void checkMorphTargetAttributeSemanticName(String semantic) {
+      // supported by the specification
+      if (semantic.startsWith("COLOR_") || semantic.startsWith("TEXCOORD_")) {
+        return;
+      }
+
       if (!context.morphAttributeAccessorFormats.containsKey(semantic) &&
           !semantic.startsWith('_')) {
         context.addIssue(SemanticError.meshPrimitiveInvalidAttribute,


### PR DESCRIPTION
Unless I'm missing something, the issue was still there.

Original issue: https://github.com/KhronosGroup/glTF-Validator/issues/178