### PR TITLE
Bump version to 2.0.0-dev.3.10

### DIFF
--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.0-dev.3.9';
+const packageVersion = '2.0.0-dev.3.10';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gltf
-version: 2.0.0-dev.3.9
+version: 2.0.0-dev.3.10
 description: Library for loading and validating glTF 2.0 assets
 homepage: https://github.com/KhronosGroup/glTF-Validator
 

--- a/test/ext/KHR_materials_dispersion/data/material/custom_property.gltf.report.json
+++ b/test/ext/KHR_materials_dispersion/data/material/custom_property.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/ext/KHR_materials_dispersion/data/material/custom_property.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.9",
+    "validatorVersion": "2.0.0-dev.3.10",
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,

--- a/test/ext/KHR_materials_dispersion/data/material/no_volume.gltf.report.json
+++ b/test/ext/KHR_materials_dispersion/data/material/no_volume.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/ext/KHR_materials_dispersion/data/material/no_volume.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.9",
+    "validatorVersion": "2.0.0-dev.3.10",
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,

--- a/test/ext/KHR_materials_dispersion/data/material/out_of_range.gltf.report.json
+++ b/test/ext/KHR_materials_dispersion/data/material/out_of_range.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/ext/KHR_materials_dispersion/data/material/out_of_range.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.9",
+    "validatorVersion": "2.0.0-dev.3.10",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,

--- a/test/ext/KHR_materials_dispersion/data/material/unexpected_extension.gltf.report.json
+++ b/test/ext/KHR_materials_dispersion/data/material/unexpected_extension.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/ext/KHR_materials_dispersion/data/material/unexpected_extension.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.9",
+    "validatorVersion": "2.0.0-dev.3.10",
     "issues": {
         "numErrors": 1,
         "numWarnings": 0,

--- a/test/ext/KHR_materials_dispersion/data/material/valid.gltf.report.json
+++ b/test/ext/KHR_materials_dispersion/data/material/valid.gltf.report.json
@@ -1,7 +1,7 @@
 {
     "uri": "test/ext/KHR_materials_dispersion/data/material/valid.gltf",
     "mimeType": "model/gltf+json",
-    "validatorVersion": "2.0.0-dev.3.9",
+    "validatorVersion": "2.0.0-dev.3.10",
     "issues": {
         "numErrors": 0,
         "numWarnings": 0,


### PR DESCRIPTION
The reports for `KHR_materials_dispersion` extension should use a newer version.