### PR TITLE
Web: Support resources in dropped directories

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -50,8 +50,10 @@
 </div>
 <div id="outputZone">
     <p><em>Validation is performed locally in your browser. Submitted assets are not uploaded.</em></p>
-    <p id="truncatedWarning" style="display: none"><em>Validation report is truncated because it contains too many
+    <p id="truncatedWarning" class="warning" style="display: none"><em>Validation report is truncated because it contains too many
         issues.</em></p>
+    <p id="fileWarning" class="warning" style="display: none"><em>The Validator is opened with the "file" URI Scheme.
+        Resources in directories are not accessible.</em></p>
     <pre><code class="language-json" id="output"></code></pre>
 </div>
 

--- a/web/styles/styles.css
+++ b/web/styles/styles.css
@@ -97,6 +97,6 @@ html, body {
     cursor: pointer;
 }
 
-#truncatedWarning {
+.warning {
     color: #c92c2c;
 }


### PR DESCRIPTION
Fixes #232.

Notes:
- Directory access is not available when the Validator is opened from a local disk, i.e., with the `file://` URI. This is a Web platform limitation.
- Directories cannot be selected from the system dialog opened by the "Select" link. This is also a web platform limitation.
- Dropping a single directory with a glTF (or GLB) asset inside is intentionally not supported.

/cc @emackey @javagl @echadwick-artist 