### PR TITLE
Change skinned mesh warning to only consider transformed parent nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### New Features
+
+* Added new `NODE_SKINNED_MESH_PARENT_TRANSFORMS` validation warning.
+
+### Changes
+
+* Changed `NODE_SKINNED_MESH_NON_ROOT` default severity to Information.
+
 ## 2.0.0-dev.3.10
 
 ### New Features

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -66,7 +66,8 @@
 |NODE_MATRIX_NON_TRS|Matrix must be decomposable to TRS.|Error|
 |NODE_MATRIX_TRS|A node can have either a matrix or any combination of translation/rotation/scale (TRS) properties.|Error|
 |NODE_SKINNED_MESH_LOCAL_TRANSFORMS|Local transforms will not affect a skinned mesh.|Warning|
-|NODE_SKINNED_MESH_NON_ROOT|Node with a skinned mesh is not root. Parent transforms will not affect a skinned mesh.|Warning|
+|NODE_SKINNED_MESH_NON_ROOT|Node with a skinned mesh is not root. Parent transforms will not affect a skinned mesh.|Information|
+|NODE_SKINNED_MESH_PARENT_TRANSFORMS|Node with a skinned mesh has parent nodes with transforms. Parent transforms will not affect a skinned mesh.|Warning|
 |NODE_SKIN_NO_SCENE|A node with a skinned mesh is used in a scene that does not contain joint nodes.|Error|
 |NON_OBJECT_EXTRAS|Prefer JSON Objects for extras.|Information|
 |NON_RELATIVE_URI|Non-relative URI found: '`%1`'.|Warning|

--- a/lib/src/base/gltf.dart
+++ b/lib/src/base/gltf.dart
@@ -308,13 +308,21 @@ class Gltf extends GltfProperty {
 
         // Node has a skinned mesh, check hierarchy and scenes
         if (node.skin != null) {
-          if (node.parent != null) {
-            context.addIssue(SemanticError.nodeSkinnedMeshNonRoot, index: i);
-          }
-
           if (node.hasTransform) {
             context.addIssue(SemanticError.nodeSkinnedMeshLocalTransforms,
                 index: i);
+          }
+          if (node.parent != null) {
+            var parent = node.parent;
+            while (parent != null) {
+              if (parent.hasTransform) {
+                context.addIssue(SemanticError.nodeSkinnedMeshParentTransforms,
+                    index: i);
+                break;
+              }
+              parent = parent.parent;
+            }
+            context.addIssue(SemanticError.nodeSkinnedMeshNonRoot, index: i);
           }
 
           final topCommonRoot = node.skin.commonRoots

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -441,16 +441,22 @@ class SemanticError extends IssueType {
   static final SemanticError nodeEmpty = SemanticError._(
       'NODE_EMPTY', (args) => 'Empty node encountered.', Severity.Information);
 
-  static final SemanticError nodeSkinnedMeshNonRoot = SemanticError._(
-      'NODE_SKINNED_MESH_NON_ROOT',
-      (args) => 'Node with a skinned mesh is not root. '
-          'Parent transforms will not affect a skinned mesh.',
-      Severity.Warning);
-
   static final SemanticError nodeSkinnedMeshLocalTransforms = SemanticError._(
       'NODE_SKINNED_MESH_LOCAL_TRANSFORMS',
       (args) => 'Local transforms will not affect a skinned mesh.',
       Severity.Warning);
+
+  static final SemanticError nodeSkinnedMeshParentTransforms = SemanticError._(
+      'NODE_SKINNED_MESH_PARENT_TRANSFORMS',
+      (args) => 'Node with a skinned mesh has parent nodes with transforms. '
+          'Parent transforms will not affect a skinned mesh.',
+      Severity.Warning);
+
+  static final SemanticError nodeSkinnedMeshNonRoot = SemanticError._(
+      'NODE_SKINNED_MESH_NON_ROOT',
+      (args) => 'Node with a skinned mesh is not root. '
+          'Parent transforms will not affect a skinned mesh.',
+      Severity.Information);
 
   static final SemanticError nodeSkinNoScene = SemanticError._(
       'NODE_SKIN_NO_SCENE',

--- a/test/base/data/skin/ignored_parent_transform.gltf.report.json
+++ b/test/base/data/skin/ignored_parent_transform.gltf.report.json
@@ -5,13 +5,19 @@
     "issues": {
         "numErrors": 0,
         "numWarnings": 1,
-        "numInfos": 1,
+        "numInfos": 2,
         "numHints": 0,
         "messages": [
             {
+                "code": "NODE_SKINNED_MESH_PARENT_TRANSFORMS",
+                "message": "Node with a skinned mesh has parent nodes with transforms. Parent transforms will not affect a skinned mesh.",
+                "severity": 1,
+                "pointer": "/nodes/2"
+            },
+            {
                 "code": "NODE_SKINNED_MESH_NON_ROOT",
                 "message": "Node with a skinned mesh is not root. Parent transforms will not affect a skinned mesh.",
-                "severity": 1,
+                "severity": 2,
                 "pointer": "/nodes/2"
             },
             {


### PR DESCRIPTION
This PR replaces `NODE_SKINNED_MESH_NON_ROOT` with `NODE_SKINNED_MESH_PARENT_TRANSFORMS` to avoid false positives for valid models. Fixes https://github.com/KhronosGroup/glTF-Validator/issues/133

I believe this check more accurately reflects the purpose of the original check. It's not that parent-child relationships entirely are considered invalid, rather that the transform aspect of skinned mesh nodes is ignored with respect to the visible mesh. The test model `ignored_parent_transform.gltf` is already set up this way, testing with a parent translated by `[1, 2, 3]`. There are valid use cases for inserting a skinned mesh into the hierarchy, for purposes like visibility, but we only need to validate for transforms.

